### PR TITLE
feat: add a button that issue an outgoing transaction

### DIFF
--- a/workflow_tracing/workflow_tracing/doctype/transaction/transaction.json
+++ b/workflow_tracing/workflow_tracing/doctype/transaction/transaction.json
@@ -23,7 +23,8 @@
   "reference_number",
   "receive_date",
   "client",
-  "company"
+  "company",
+  "parent_transaction"
  ],
  "fields": [
   {
@@ -137,11 +138,17 @@
    "hidden": 1,
    "label": "Sub Department Link",
    "options": "DocType"
+  },
+  {
+   "fieldname": "parent_transaction",
+   "fieldtype": "Link",
+   "label": "Parent Transaction",
+   "options": "Transaction"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-04-23 21:09:46.071317",
+ "modified": "2024-04-26 10:59:35.764356",
  "modified_by": "Administrator",
  "module": "Workflow Tracing",
  "name": "Transaction",


### PR DESCRIPTION
The button is on the incoming transaction to issue an outgoing transaction for it

Filling out some fields of new transaction(outgoing) based on the incoming transaction